### PR TITLE
Use alternative bare DELETE endpoint and simplify testing

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -53,8 +53,9 @@ test {
     }
     finalizedBy jacocoTestReport
     environment "ALLOWED_ORIGIN", "*"
-    environment "BARE_API_KEY","bareApikey"
-    environment "BARE_HOST", "www.example.com";
+    environment "PERSON_AUTHORITY_BASE_ADDRESS", "https://localhost/person"
+    environment "BARE_HOST","www.example.com"
+    environment "BARE_API_KEY","someKey"
 }
 
 pmd {

--- a/src/main/java/no/unit/nva/bare/AddNewAuthorityIdentifierHandler.java
+++ b/src/main/java/no/unit/nva/bare/AddNewAuthorityIdentifierHandler.java
@@ -48,17 +48,16 @@ public class AddNewAuthorityIdentifierHandler extends ApiGatewayHandler<AddNewAu
      */
     @JacocoGenerated
     public AddNewAuthorityIdentifierHandler() {
-        this(new Environment(), new BareConnection());
+        this(new BareConnection());
     }
 
     /**
      * Constructor for AddNewAuthorityIdentifierHandler.
      *
-     * @param environment    environment
      * @param bareConnection bareConnection
      */
-    public AddNewAuthorityIdentifierHandler(Environment environment, BareConnection bareConnection) {
-        super(AddNewAuthorityIdentifierRequest.class, environment);
+    public AddNewAuthorityIdentifierHandler( BareConnection bareConnection) {
+        super(AddNewAuthorityIdentifierRequest.class, new Environment());
         this.bareConnection = bareConnection;
     }
 
@@ -124,7 +123,7 @@ public class AddNewAuthorityIdentifierHandler extends ApiGatewayHandler<AddNewAu
         try {
             final BareAuthority updatedAuthority = bareConnection.get(scn);
             if (Objects.nonNull(updatedAuthority)) {
-                AuthorityConverter authorityConverter = new AuthorityConverter(environment);
+                AuthorityConverter authorityConverter = new AuthorityConverter();
                 return authorityConverter.asAuthority(updatedAuthority);
             } else {
                 logger.info(COMMUNICATION_ERROR_WHILE_RETRIEVING_UPDATED_AUTHORITY);

--- a/src/main/java/no/unit/nva/bare/BareConnection.java
+++ b/src/main/java/no/unit/nva/bare/BareConnection.java
@@ -26,8 +26,9 @@ public class BareConnection {
     public static final String SPACE = " ";
     public static final String EMPTY_FRAGMENT = null;
     public static final String QUERY_PERSON_AUTHORITIES = "q=%s+authoritytype:person&start=1&max=10&format=json";
+    public static final String QUERY_SPECIFY_AUTHORITY_IDENTIFIER = "identifier=%s";
     public static final String PATH_TO_AUTHORITY_TEMPLATE = "/authority/rest/authorities/v2/%s";
-    public static final String AUTHORITY_IDENTIFIER_PATH = "/authority/rest/authorities/v2/%s/identifiers/%s/%s";
+    public static final String DELETE_AUTHORITY_IDENTIFIER_PATH = "/authority/rest/authorities/v2/%s/identifiers/%s";
     public static final Duration TIMEOUT_DURATION = Duration.ofSeconds(15);
 
     public static final String ADD_NEW_AUTHORITY_IDENTIFIER_PATH = "/authority/rest/authorities/v2/%s/identifiers";
@@ -87,7 +88,7 @@ public class BareConnection {
                URISyntaxException, InterruptedException {
         String addIdentifierPath =
             String.format(ADD_NEW_AUTHORITY_IDENTIFIER_PATH, authoritySystemControlNumber);
-        URI uri = new URI(HTTPS, BARE_HOST, addIdentifierPath,EMPTY_QUERY, EMPTY_FRAGMENT);
+        URI uri = new URI(HTTPS, BARE_HOST, addIdentifierPath, EMPTY_QUERY, EMPTY_FRAGMENT);
 
         final String body = objectMapperWithEmpty.writeValueAsString(authorityIdentifier);
         HttpRequest.BodyPublisher bodyPublisher = HttpRequest.BodyPublishers.ofString(body);
@@ -132,9 +133,9 @@ public class BareConnection {
      */
     public HttpResponse<String> deleteIdentifier(String systemControlNumber, String qualifier, String identifier)
         throws IOException, URISyntaxException, InterruptedException {
-        String identifierPath = createIdentifierPath(systemControlNumber, qualifier, identifier);
-        URI uri = new URI(HTTPS, BARE_HOST, identifierPath, EMPTY_QUERY, EMPTY_FRAGMENT);
-
+        String qualifierPath = String.format(DELETE_AUTHORITY_IDENTIFIER_PATH, systemControlNumber, qualifier);
+        String deleteIdentifierQuery = String.format(QUERY_SPECIFY_AUTHORITY_IDENTIFIER, identifier);
+        URI uri = new URI(HTTPS, BARE_HOST, qualifierPath, deleteIdentifierQuery, EMPTY_FRAGMENT);
         final HttpRequest.Builder requestBuilder = getHttpRequestBuilder(uri);
         HttpRequest request = requestBuilder.DELETE().build();
         return sendRequest(request);
@@ -185,10 +186,6 @@ public class BareConnection {
 
     private HttpResponse<String> sendRequest(HttpRequest request) throws IOException, InterruptedException {
         return httpClient.send(request, HttpResponse.BodyHandlers.ofString());
-    }
-
-    private String createIdentifierPath(String systemControlNumber, String qualifier, String identifier) {
-        return String.format(AUTHORITY_IDENTIFIER_PATH, systemControlNumber, qualifier, identifier);
     }
 
     private HttpRequest.Builder getHttpRequestBuilder(URI uri) {

--- a/src/main/java/no/unit/nva/bare/Config.java
+++ b/src/main/java/no/unit/nva/bare/Config.java
@@ -8,11 +8,13 @@ public final class Config {
     public static final String MISSING_ENVIRONMENT_VARIABLES = "Missing environment variables";
     public static final String CORS_ALLOW_ORIGIN = readEnv("ALLOWED_ORIGIN");
     public static final String BARE_APIKEY = readEnv("BARE_API_KEY");
+    public static final String PERSON_AUTHORITY_BASE_ADDRESS = readEnv("PERSON_AUTHORITY_BASE_ADDRESS");
     public static final String PATH_SEPARATOR = "/";
     public static final String BARE_HOST = setupBareHost(readEnv("BARE_HOST"));
     public static final String BARE_QUERY_PATH = "/authority/rest/functions/v2/query";
     public static final String BARE_CREATE_PATH = "/authority/rest/authorities/v2";
     public static final String BARE_GET_PATH = "/authority/rest/authorities/v2";
+
 
     private Config() {
     }

--- a/src/main/java/no/unit/nva/bare/CreateAuthorityHandler.java
+++ b/src/main/java/no/unit/nva/bare/CreateAuthorityHandler.java
@@ -34,11 +34,11 @@ public class CreateAuthorityHandler extends ApiGatewayHandler<CreateAuthorityReq
     protected final transient BareConnection bareConnection;
 
     public CreateAuthorityHandler() {
-        this(new BareConnection(), new Environment());
+        this(new BareConnection());
     }
 
-    public CreateAuthorityHandler(BareConnection bareConnection, Environment environment) {
-        super(CreateAuthorityRequest.class, environment);
+    public CreateAuthorityHandler(BareConnection bareConnection) {
+        super(CreateAuthorityRequest.class, new Environment());
         this.bareConnection = bareConnection;
     }
 
@@ -47,7 +47,7 @@ public class CreateAuthorityHandler extends ApiGatewayHandler<CreateAuthorityReq
         throws ApiGatewayException {
         validateInput(input);
         BareAuthority bareAuthority = createAuthorityOnBare(input.getInvertedName());
-        return new AuthorityConverter(environment).asAuthority(bareAuthority);
+        return new AuthorityConverter().asAuthority(bareAuthority);
     }
 
     @Override
@@ -56,7 +56,7 @@ public class CreateAuthorityHandler extends ApiGatewayHandler<CreateAuthorityReq
     }
 
     protected BareAuthority createAuthorityOnBare(String name) throws BadGatewayException {
-        AuthorityConverter authorityConverter = new AuthorityConverter(environment);
+        AuthorityConverter authorityConverter = new AuthorityConverter();
         BareAuthority bareAuthority = authorityConverter.buildAuthority(name);
 
         HttpResponse<String> response = attempt(() -> bareConnection.createAuthority(bareAuthority))

--- a/src/main/java/no/unit/nva/bare/DeleteAuthorityIdentifierHandler.java
+++ b/src/main/java/no/unit/nva/bare/DeleteAuthorityIdentifierHandler.java
@@ -124,7 +124,7 @@ public class DeleteAuthorityIdentifierHandler extends ApiGatewayHandler<DeleteAu
         try {
             final BareAuthority updatedAuthority = bareConnection.get(scn);
             if (Objects.nonNull(updatedAuthority)) {
-                AuthorityConverter authorityConverter = new AuthorityConverter(environment);
+                AuthorityConverter authorityConverter = new AuthorityConverter();
                 return authorityConverter.asAuthority(updatedAuthority);
             } else {
                 logger.error(COMMUNICATION_ERROR_WHILE_RETRIEVING_UPDATED_AUTHORITY);

--- a/src/main/java/no/unit/nva/bare/FetchAuthorityHandler.java
+++ b/src/main/java/no/unit/nva/bare/FetchAuthorityHandler.java
@@ -11,7 +11,6 @@ import java.io.IOException;
 import java.net.URISyntaxException;
 import java.util.List;
 import java.util.Map;
-import nva.commons.core.Environment;
 import nva.commons.core.JacocoGenerated;
 import nva.commons.core.exceptions.ExceptionUtils;
 import org.slf4j.Logger;
@@ -36,12 +35,12 @@ public class FetchAuthorityHandler implements RequestHandler<Map<String, Object>
 
     @JacocoGenerated
     public FetchAuthorityHandler() {
-        this(new BareConnection(), new Environment());
+        this(new BareConnection());
     }
 
-    public FetchAuthorityHandler(BareConnection bareConnection, Environment environment) {
+    public FetchAuthorityHandler(BareConnection bareConnection) {
         this.bareConnection = bareConnection;
-        this.authorityConverter = new AuthorityConverter(environment);
+        this.authorityConverter = new AuthorityConverter();
     }
 
     /**

--- a/src/main/java/no/unit/nva/bare/UpdateAuthorityIdentifierHandler.java
+++ b/src/main/java/no/unit/nva/bare/UpdateAuthorityIdentifierHandler.java
@@ -53,17 +53,16 @@ public class UpdateAuthorityIdentifierHandler extends ApiGatewayHandler<UpdateAu
     @JacocoGenerated
     @JsonCreator
     public UpdateAuthorityIdentifierHandler() {
-        this(new Environment(), new BareConnection());
+        this(new BareConnection());
     }
 
     /**
      * Constructor for UpdateAuthorityIdentifierHandler.
      *
-     * @param environment    environment
      * @param bareConnection bareConnection
      */
-    public UpdateAuthorityIdentifierHandler(Environment environment, BareConnection bareConnection) {
-        super(UpdateAuthorityIdentifierRequest.class, environment);
+    public UpdateAuthorityIdentifierHandler(BareConnection bareConnection) {
+        super(UpdateAuthorityIdentifierRequest.class, new Environment());
         this.bareConnection = bareConnection;
     }
 
@@ -137,7 +136,7 @@ public class UpdateAuthorityIdentifierHandler extends ApiGatewayHandler<UpdateAu
         try {
             final BareAuthority updatedAuthority = bareConnection.get(scn);
             if (Objects.nonNull(updatedAuthority)) {
-                AuthorityConverter authorityConverter = new AuthorityConverter(environment);
+                AuthorityConverter authorityConverter = new AuthorityConverter();
                 return authorityConverter.asAuthority(updatedAuthority);
             } else {
                 logger.error(COMMUNICATION_ERROR_WHILE_RETRIEVING_UPDATED_AUTHORITY);

--- a/src/test/java/no/unit/nva/bare/AddNewAuthorityIdentifierHandlerTest.java
+++ b/src/test/java/no/unit/nva/bare/AddNewAuthorityIdentifierHandlerTest.java
@@ -11,8 +11,6 @@ import static no.unit.nva.bare.AddNewAuthorityIdentifierHandler.MISSING_REQUEST_
 import static no.unit.nva.bare.AddNewAuthorityIdentifierHandler.QUALIFIER_KEY;
 import static no.unit.nva.bare.AddNewAuthorityIdentifierHandler.REMOTE_SERVER_ERRORMESSAGE;
 import static no.unit.nva.bare.AddNewAuthorityIdentifierHandler.SCN_KEY;
-import static no.unit.nva.bare.AuthorityConverterTest.HTTPS_LOCALHOST_PERSON;
-import static nva.commons.apigateway.ApiGatewayHandler.ALLOWED_ORIGIN_ENV;
 import static nva.commons.core.JsonUtils.objectMapperWithEmpty;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
@@ -34,7 +32,6 @@ import no.unit.nva.testutils.HandlerRequestBuilder;
 import no.unit.nva.testutils.IoUtils;
 import no.unit.nva.testutils.TestHeaders;
 import nva.commons.apigateway.GatewayResponse;
-import nva.commons.core.Environment;
 import nva.commons.core.StringUtils;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
@@ -50,7 +47,6 @@ public class AddNewAuthorityIdentifierHandlerTest {
     public static final String BARE_SINGLE_AUTHORITY_GET_RESPONSE_JSON = "bareSingleAuthorityGetResponse.json";
     public static final String EXCEPTION_IS_EXPECTED = "Exception is expected.";
 
-    private Environment mockEnvironment;
     private Context context;
     private BareConnection bareConnection;
     private ByteArrayOutputStream output;
@@ -62,10 +58,7 @@ public class AddNewAuthorityIdentifierHandlerTest {
      */
     @BeforeEach
     public void setUp() {
-        mockEnvironment = mock(Environment.class);
-        when(mockEnvironment.readEnv(ALLOWED_ORIGIN_ENV)).thenReturn("*");
-        when(mockEnvironment.readEnv(AuthorityConverter.PERSON_AUTHORITY_BASE_ADDRESS_KEY))
-            .thenReturn(HTTPS_LOCALHOST_PERSON);
+
         context = mock(Context.class);
         output = new ByteArrayOutputStream();
         bareConnection = mock(BareConnection.class);
@@ -78,7 +71,7 @@ public class AddNewAuthorityIdentifierHandlerTest {
 
         InputStream input = new HandlerRequestBuilder<AddNewAuthorityIdentifierRequest>(objectMapperWithEmpty)
             .build();
-        addNewAuthorityIdentifierHandler = new AddNewAuthorityIdentifierHandler(mockEnvironment, bareConnection);
+        addNewAuthorityIdentifierHandler = new AddNewAuthorityIdentifierHandler(bareConnection);
         addNewAuthorityIdentifierHandler.handleRequest(input, output, context);
 
         GatewayResponse<Problem> gatewayResponse = GatewayResponse.fromOutputStream(output);
@@ -97,7 +90,7 @@ public class AddNewAuthorityIdentifierHandlerTest {
         Map<String, String> pathParams = getPathParameters(MOCK_SCN_VALUE, null);
         InputStream input = createRequest(pathParams, null);
 
-        addNewAuthorityIdentifierHandler = new AddNewAuthorityIdentifierHandler(mockEnvironment, bareConnection);
+        addNewAuthorityIdentifierHandler = new AddNewAuthorityIdentifierHandler(bareConnection);
         addNewAuthorityIdentifierHandler.handleRequest(input, output, context);
 
         GatewayResponse<Problem> gatewayResponse = GatewayResponse.fromOutputStream(output);
@@ -116,7 +109,7 @@ public class AddNewAuthorityIdentifierHandlerTest {
         Map<String, String> pathParams = getPathParameters(MOCK_SCN_VALUE,
                                                            ValidIdentifierKey.ORGUNITID.asString() + "invalid");
         InputStream input = createRequest(pathParams, null);
-        addNewAuthorityIdentifierHandler = new AddNewAuthorityIdentifierHandler(mockEnvironment, bareConnection);
+        addNewAuthorityIdentifierHandler = new AddNewAuthorityIdentifierHandler(bareConnection);
         addNewAuthorityIdentifierHandler.handleRequest(input, output, context);
 
         GatewayResponse<Problem> gatewayResponse = GatewayResponse.fromOutputStream(output);
@@ -134,7 +127,7 @@ public class AddNewAuthorityIdentifierHandlerTest {
         Map<String, String> pathParams = getPathParameters(MOCK_SCN_VALUE, ValidIdentifierKey.ORGUNITID.asString());
         InputStream input = createRequest(pathParams, null);
 
-        addNewAuthorityIdentifierHandler = new AddNewAuthorityIdentifierHandler(mockEnvironment, bareConnection);
+        addNewAuthorityIdentifierHandler = new AddNewAuthorityIdentifierHandler(bareConnection);
         addNewAuthorityIdentifierHandler.handleRequest(input, output, context);
 
         GatewayResponse<Problem> gatewayResponse = GatewayResponse.fromOutputStream(output);
@@ -158,7 +151,7 @@ public class AddNewAuthorityIdentifierHandlerTest {
             .withHeaders(TestHeaders.getRequestHeaders())
             .build();
 
-        addNewAuthorityIdentifierHandler = new AddNewAuthorityIdentifierHandler(mockEnvironment, bareConnection);
+        addNewAuthorityIdentifierHandler = new AddNewAuthorityIdentifierHandler(bareConnection);
         addNewAuthorityIdentifierHandler.handleRequest(input, output, context);
 
         GatewayResponse<Problem> gatewayResponse = GatewayResponse.fromOutputStream(output);
@@ -175,12 +168,13 @@ public class AddNewAuthorityIdentifierHandlerTest {
     public void handlerReturnsOkWhenInputIsValidAndAuthorityIdentifierIsAddedSuccessfully() throws Exception {
 
         InputStream is = IoUtils.inputStreamFromResources(BARE_SINGLE_AUTHORITY_GET_RESPONSE_JSON);
-        final BareAuthority bareAuthority = objectMapperWithEmpty.readValue(new InputStreamReader(is), BareAuthority.class);
+        final BareAuthority bareAuthority = objectMapperWithEmpty.readValue(new InputStreamReader(is),
+                                                                            BareAuthority.class);
         when(bareConnection.get(anyString())).thenReturn(bareAuthority);
         when(httpResponse.statusCode()).thenReturn(HTTP_OK);
         when(bareConnection.addNewIdentifier(any(), any())).thenReturn(httpResponse);
 
-        addNewAuthorityIdentifierHandler = new AddNewAuthorityIdentifierHandler(mockEnvironment, bareConnection);
+        addNewAuthorityIdentifierHandler = new AddNewAuthorityIdentifierHandler(bareConnection);
         AddNewAuthorityIdentifierRequest requestObject = new AddNewAuthorityIdentifierRequest(MOCK_FEIDEID_VALUE);
         Map<String, String> pathParams = getPathParameters(MOCK_SCN_VALUE, ValidIdentifierKey.FEIDEID.asString());
         InputStream input = createRequest(pathParams, requestObject);
@@ -197,7 +191,7 @@ public class AddNewAuthorityIdentifierHandlerTest {
         when(bareConnection.addNewIdentifier(any(), any())).thenThrow(
             new IOException(EXCEPTION_IS_EXPECTED));
 
-        addNewAuthorityIdentifierHandler = new AddNewAuthorityIdentifierHandler(mockEnvironment, bareConnection);
+        addNewAuthorityIdentifierHandler = new AddNewAuthorityIdentifierHandler(bareConnection);
         AddNewAuthorityIdentifierRequest requestObject = new AddNewAuthorityIdentifierRequest(MOCK_FEIDEID_VALUE);
         Map<String, String> pathParams = getPathParameters(MOCK_SCN_VALUE, ValidIdentifierKey.FEIDEID.asString());
         InputStream input = createRequest(pathParams, requestObject);
@@ -219,7 +213,7 @@ public class AddNewAuthorityIdentifierHandlerTest {
         when(bareConnection.get(any())).thenReturn(null);
         when(bareConnection.addNewIdentifier(any(), any())).thenReturn(httpResponse);
 
-        addNewAuthorityIdentifierHandler = new AddNewAuthorityIdentifierHandler(mockEnvironment, bareConnection);
+        addNewAuthorityIdentifierHandler = new AddNewAuthorityIdentifierHandler(bareConnection);
         AddNewAuthorityIdentifierRequest requestObject = new AddNewAuthorityIdentifierRequest(MOCK_FEIDEID_VALUE);
         Map<String, String> pathParams = getPathParameters(MOCK_SCN_VALUE, ValidIdentifierKey.FEIDEID.asString());
         InputStream input = createRequest(pathParams, requestObject);
@@ -241,7 +235,7 @@ public class AddNewAuthorityIdentifierHandlerTest {
         when(bareConnection.get(any())).thenThrow(new IOException(EXCEPTION_IS_EXPECTED));
         when(bareConnection.addNewIdentifier(any(), any())).thenReturn(httpResponse);
 
-        addNewAuthorityIdentifierHandler = new AddNewAuthorityIdentifierHandler(mockEnvironment, bareConnection);
+        addNewAuthorityIdentifierHandler = new AddNewAuthorityIdentifierHandler(bareConnection);
         AddNewAuthorityIdentifierRequest requestObject = new AddNewAuthorityIdentifierRequest(MOCK_FEIDEID_VALUE);
         Map<String, String> pathParams = getPathParameters(MOCK_SCN_VALUE, ValidIdentifierKey.FEIDEID.asString());
         InputStream input = createRequest(pathParams, requestObject);
@@ -261,7 +255,7 @@ public class AddNewAuthorityIdentifierHandlerTest {
 
         when(httpResponse.statusCode()).thenReturn(HTTP_FORBIDDEN);
         when(bareConnection.addNewIdentifier(any(), any())).thenReturn(httpResponse);
-        addNewAuthorityIdentifierHandler = new AddNewAuthorityIdentifierHandler(mockEnvironment, bareConnection);
+        addNewAuthorityIdentifierHandler = new AddNewAuthorityIdentifierHandler(bareConnection);
         AddNewAuthorityIdentifierRequest requestObject = new AddNewAuthorityIdentifierRequest(MOCK_FEIDEID_VALUE);
         Map<String, String> pathParams = getPathParameters(MOCK_SCN_VALUE, ValidIdentifierKey.FEIDEID.asString());
         InputStream input = createRequest(pathParams, requestObject);

--- a/src/test/java/no/unit/nva/bare/AuthorityConverterTest.java
+++ b/src/test/java/no/unit/nva/bare/AuthorityConverterTest.java
@@ -2,14 +2,11 @@ package no.unit.nva.bare;
 
 import static nva.commons.core.JsonUtils.objectMapperWithEmpty;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.net.URI;
 import java.nio.file.Paths;
-import nva.commons.core.Environment;
 import nva.commons.core.ioutils.IoUtils;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -23,9 +20,7 @@ public class AuthorityConverterTest {
             "createAuthorityRequestToBare.json";
     public static final String INVERTED_NAME = "Unit, DotNo";
     public static final String HTTPS_LOCALHOST_PERSON = "https://localhost/person/";
-    public static final String HTTPS_LOCALHOST_PERSON_WITHOUT_TRAILING_SLASH = "https://localhost/person";
-    public static final String SYSTEM_CONTROL_NUMBER = "1";
-    private Environment mockEnvironment;
+
 
 
     /**
@@ -33,34 +28,14 @@ public class AuthorityConverterTest {
      */
     @BeforeEach
     public void setUp() {
-        mockEnvironment = mock(Environment.class);
-        when(mockEnvironment.readEnv(AuthorityConverter.PERSON_AUTHORITY_BASE_ADDRESS_KEY))
-                .thenReturn(HTTPS_LOCALHOST_PERSON);
+
     }
-
-
-    @Test
-    public void testTrailingSlashInPersonAuthorityBaseAddress() throws IOException {
-        Environment mockEnvironmentWithoutTrailingSlash = mock(Environment.class);
-        when(mockEnvironmentWithoutTrailingSlash.readEnv(AuthorityConverter.PERSON_AUTHORITY_BASE_ADDRESS_KEY))
-                .thenReturn(HTTPS_LOCALHOST_PERSON_WITHOUT_TRAILING_SLASH);
-
-        InputStream streamResp =
-                IoUtils.inputStreamFromResources(Paths.get(BARE_SINGLE_AUTHORITY_GET_RESPONSE_WITH_ALL_IDS_JSON));
-        final BareAuthority bareAuthority = objectMapperWithEmpty.readValue(new InputStreamReader(streamResp), BareAuthority.class);
-        bareAuthority.setSystemControlNumber(SYSTEM_CONTROL_NUMBER);
-        AuthorityConverter authorityConverter = new AuthorityConverter(mockEnvironmentWithoutTrailingSlash);
-        Authority authority  = authorityConverter.asAuthority(bareAuthority);
-        URI expectedId = URI.create(HTTPS_LOCALHOST_PERSON + SYSTEM_CONTROL_NUMBER);
-        assertEquals(expectedId, authority.getId());
-    }
-
 
     @Test
     public void testEmptyBareAuthority() throws IOException {
         InputStream streamResp =
                 IoUtils.inputStreamFromResources(BARE_SINGLE_AUTHORITY_GET_RESPONSE_WITH_ALL_IDS_JSON);
-        AuthorityConverter authorityConverter = new AuthorityConverter(mockEnvironment);
+        AuthorityConverter authorityConverter = new AuthorityConverter();
         final BareAuthority bareAuthority = objectMapperWithEmpty.readValue(new InputStreamReader(streamResp), BareAuthority.class);
         final String value = authorityConverter.findValueIn(bareAuthority, "whatEver");
         assertEquals("", value);
@@ -70,7 +45,7 @@ public class AuthorityConverterTest {
     public void testBuildAuthority() throws IOException {
         InputStream streamResp = IoUtils.inputStreamFromResources(CREATE_AUTHORITY_REQUEST_TO_BARE_JSON);
         final BareAuthority expectedAuth = objectMapperWithEmpty.readValue(new InputStreamReader(streamResp), BareAuthority.class);
-        AuthorityConverter authorityConverter = new AuthorityConverter(mockEnvironment);
+        AuthorityConverter authorityConverter = new AuthorityConverter();
         final BareAuthority bareAuthority = authorityConverter.buildAuthority(INVERTED_NAME);
         assertEquals(expectedAuth.getStatus(), bareAuthority.getStatus());
         assertEquals(expectedAuth.getAuthorityType(), bareAuthority.getAuthorityType());

--- a/src/test/java/no/unit/nva/bare/BareConnectionTest.java
+++ b/src/test/java/no/unit/nva/bare/BareConnectionTest.java
@@ -44,9 +44,6 @@ public class BareConnectionTest {
     public void setUp() {
         mockHttpClient = mock(HttpClient.class);
         mockHttpResponse = mock(HttpResponse.class);
-        mockEnvironment = mock(Environment.class);
-        when(mockEnvironment.readEnv(AuthorityConverter.PERSON_AUTHORITY_BASE_ADDRESS_KEY))
-            .thenReturn(HTTPS_LOCALHOST_PERSON);
     }
 
     @Test
@@ -163,7 +160,7 @@ public class BareConnectionTest {
 
         BareConnection mockBareConnection = new BareConnection(mockHttpClient);
 
-        AuthorityConverter authorityConverter = new AuthorityConverter(mockEnvironment);
+        AuthorityConverter authorityConverter = new AuthorityConverter();
         BareAuthority bareAuthority = authorityConverter.buildAuthority(MOCK_NAME);
         HttpResponse<String> httpResponse = mockBareConnection.createAuthority(bareAuthority);
 
@@ -190,7 +187,7 @@ public class BareConnectionTest {
     }
 
     @Test
-    public void testGetMethodOnBareConnection_ResponseFail() throws IOException, URISyntaxException,
+    public void testGetMethodOnBareConnection_ResponseFail() throws IOException,
                                                                     InterruptedException {
         BareConnection bareConnection = new BareConnection(mockHttpClient);
 

--- a/src/test/java/no/unit/nva/bare/CreateAuthorityHandlerTest.java
+++ b/src/test/java/no/unit/nva/bare/CreateAuthorityHandlerTest.java
@@ -5,7 +5,6 @@ import static java.net.HttpURLConnection.HTTP_CREATED;
 import static java.net.HttpURLConnection.HTTP_INTERNAL_ERROR;
 import static java.net.HttpURLConnection.HTTP_NOT_ACCEPTABLE;
 import static java.net.HttpURLConnection.HTTP_OK;
-import static no.unit.nva.bare.AuthorityConverterTest.HTTPS_LOCALHOST_PERSON;
 import static no.unit.nva.bare.CreateAuthorityRequest.MALFORMED_NAME_VALUE;
 import static nva.commons.core.JsonUtils.objectMapperWithEmpty;
 import static nva.commons.core.attempt.Try.attempt;
@@ -28,7 +27,6 @@ import java.util.HashMap;
 import java.util.Map;
 import no.unit.nva.testutils.HandlerRequestBuilder;
 import nva.commons.apigateway.GatewayResponse;
-import nva.commons.core.Environment;
 import nva.commons.core.ioutils.IoUtils;
 import nva.commons.logutils.LogUtils;
 import nva.commons.logutils.TestAppender;
@@ -41,15 +39,13 @@ public class CreateAuthorityHandlerTest {
     public static final String BODY_KEY = "body";
     public static final String MOCK_NAME = "Unit, DotNo";
     public static final String MOCK_BODY = "{\"invertedname\": \"" + MOCK_NAME + "\"}";
-    public static final String MOCK_BODY_NOT_INVERTED = "{\"invertedname\": \"no comma\"}";
-    public static final String MOCK_BODY_NONAME = "{\"noname\": \"" + MOCK_NAME + "\"}";
+
     public static final String CREATE_AUTHORITY_GATEWAY_RESPONSE_BODY_JSON = "createAuthorityGatewayResponseBody.json";
     public static final String BARE_SINGLE_AUTHORITY_CREATE_RESPONSE = "bareSingleAuthorityCreateResponse.json";
     public static final String MOCK_ERROR_MESSAGE = "I want to fail";
     private static final Context CONTEXT = mock(Context.class);
     private BareConnection mockBareConnection;
     private HttpResponse mockHttpResponse;
-    private Environment mockEnvironment;
     private ByteArrayOutputStream outputStream;
 
     /**
@@ -61,10 +57,6 @@ public class CreateAuthorityHandlerTest {
         outputStream = new ByteArrayOutputStream();
         mockHttpResponse = mock(HttpResponse.class);
         mockBareConnection = mock(BareConnection.class);
-        mockEnvironment = mock(Environment.class);
-        when(mockEnvironment.readEnv(AuthorityConverter.PERSON_AUTHORITY_BASE_ADDRESS_KEY))
-            .thenReturn(HTTPS_LOCALHOST_PERSON);
-        when(mockEnvironment.readEnv("ALLOWED_ORIGIN")).thenReturn("*");
     }
 
     @Test
@@ -77,7 +69,7 @@ public class CreateAuthorityHandlerTest {
         when(mockHttpResponse.body()).thenReturn(mockBody);
         when(mockBareConnection.createAuthority(any())).thenReturn(mockHttpResponse);
 
-        CreateAuthorityHandler createAuthorityHandler = new CreateAuthorityHandler(mockBareConnection, mockEnvironment);
+        CreateAuthorityHandler createAuthorityHandler = new CreateAuthorityHandler(mockBareConnection);
         createAuthorityHandler.handleRequest(sampleRequest(), outputStream, CONTEXT);
         GatewayResponse<Authority> response = GatewayResponse.fromOutputStream(outputStream);
         assertEquals(HTTP_OK, response.getStatusCode());
@@ -96,7 +88,7 @@ public class CreateAuthorityHandlerTest {
         when(mockHttpResponse.body()).thenReturn(emptyResponse);
         when(mockBareConnection.createAuthority(any())).thenReturn(mockHttpResponse);
 
-        CreateAuthorityHandler createAuthorityHandler = new CreateAuthorityHandler(mockBareConnection, mockEnvironment);
+        CreateAuthorityHandler createAuthorityHandler = new CreateAuthorityHandler(mockBareConnection);
         createAuthorityHandler.handleRequest(sampleRequest(), outputStream, CONTEXT);
         GatewayResponse<Authority> response = GatewayResponse.fromOutputStream(outputStream);
 
@@ -110,7 +102,7 @@ public class CreateAuthorityHandlerTest {
         when(mockHttpResponse.statusCode()).thenReturn(HTTP_NOT_ACCEPTABLE);
         when(mockHttpResponse.body()).thenReturn(MOCK_ERROR_MESSAGE);
         when(mockBareConnection.createAuthority(any())).thenReturn(mockHttpResponse);
-        CreateAuthorityHandler createAuthorityHandler = new CreateAuthorityHandler(mockBareConnection, mockEnvironment);
+        CreateAuthorityHandler createAuthorityHandler = new CreateAuthorityHandler(mockBareConnection);
 
         createAuthorityHandler.handleRequest(sampleRequest(), outputStream, CONTEXT);
         GatewayResponse<Authority> response = GatewayResponse.fromOutputStream(outputStream);
@@ -123,7 +115,7 @@ public class CreateAuthorityHandlerTest {
     public void testCreateAuthority_ExceptionFromBare() throws IOException, URISyntaxException, InterruptedException {
         final TestAppender logger = LogUtils.getTestingAppenderForRootLogger();
         when(mockBareConnection.createAuthority(any())).thenThrow(new IOException(MOCK_ERROR_MESSAGE));
-        CreateAuthorityHandler createAuthorityHandler = new CreateAuthorityHandler(mockBareConnection, mockEnvironment);
+        CreateAuthorityHandler createAuthorityHandler = new CreateAuthorityHandler(mockBareConnection);
         createAuthorityHandler.handleRequest(sampleRequest(), outputStream, CONTEXT);
         GatewayResponse<Authority> response = GatewayResponse.fromOutputStream(outputStream);
 
@@ -134,7 +126,7 @@ public class CreateAuthorityHandlerTest {
     @Test
     public void testCreateAuthorityMissingBodyParam_Name() throws IOException {
         final TestAppender logger = LogUtils.getTestingAppenderForRootLogger();
-        CreateAuthorityHandler createAuthorityHandler = new CreateAuthorityHandler(mockBareConnection, mockEnvironment);
+        CreateAuthorityHandler createAuthorityHandler = new CreateAuthorityHandler(mockBareConnection);
         createAuthorityHandler.handleRequest(emptyRequest(), outputStream, CONTEXT);
         GatewayResponse<Authority> response = GatewayResponse.fromOutputStream(outputStream);
 

--- a/src/test/java/no/unit/nva/bare/DeleteAuthorityIdentifierHandlerTest.java
+++ b/src/test/java/no/unit/nva/bare/DeleteAuthorityIdentifierHandlerTest.java
@@ -18,20 +18,26 @@ import static nva.commons.core.JsonUtils.objectMapperWithEmpty;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.core.Is.is;
+import static org.hamcrest.core.IsEqual.equalTo;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import com.amazonaws.services.lambda.runtime.Context;
+import com.fasterxml.jackson.core.JsonProcessingException;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.OutputStream;
+import java.net.HttpURLConnection;
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.net.http.HttpResponse;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
+import no.unit.nva.testutils.HandlerRequestBuilder;
 import no.unit.nva.testutils.HandlerUtils;
 import no.unit.nva.testutils.TestHeaders;
 import nva.commons.apigateway.GatewayResponse;
@@ -49,11 +55,12 @@ public class DeleteAuthorityIdentifierHandlerTest {
     public static final String MOCK_FEIDEID_VALUE = "feideid";
     public static final String BARE_SINGLE_AUTHORITY_GET_RESPONSE_JSON = "/bareSingleAuthorityGetResponse.json";
     public static final String EXCEPTION_IS_EXPECTED = "Exception is expected.";
+    private static final Context CONTEXT = mock(Context.class);
 
     private Environment mockEnvironment;
     private Context context;
     private BareConnection bareConnection;
-    private OutputStream output;
+    private ByteArrayOutputStream output;
     private DeleteAuthorityIdentifierHandler deleteAuthorityIdentifierHandler;
     private HttpResponse httpResponse;
 
@@ -64,8 +71,7 @@ public class DeleteAuthorityIdentifierHandlerTest {
     public void setUp() {
         mockEnvironment = mock(Environment.class);
         when(mockEnvironment.readEnv(ALLOWED_ORIGIN_ENV)).thenReturn("*");
-        when(mockEnvironment.readEnv(AuthorityConverter.PERSON_AUTHORITY_BASE_ADDRESS_KEY))
-            .thenReturn(HTTPS_LOCALHOST_PERSON);
+
 
         context = mock(Context.class);
         output = new ByteArrayOutputStream();
@@ -311,6 +317,7 @@ public class DeleteAuthorityIdentifierHandlerTest {
         assertThat(problem.getTitle(), containsString(Status.INTERNAL_SERVER_ERROR.getReasonPhrase()));
         assertThat(problem.getStatus(), is(Status.INTERNAL_SERVER_ERROR));
     }
+
 
     private Map<String, String> getPathParameters(String scn, String qualifier) {
         Map<String, String> pathParams = new ConcurrentHashMap<>();

--- a/src/test/java/no/unit/nva/bare/FetchAuthorityHandlerTest.java
+++ b/src/test/java/no/unit/nva/bare/FetchAuthorityHandlerTest.java
@@ -4,7 +4,6 @@ import static java.net.HttpURLConnection.HTTP_BAD_REQUEST;
 import static java.net.HttpURLConnection.HTTP_INTERNAL_ERROR;
 import static java.net.HttpURLConnection.HTTP_OK;
 import static no.unit.nva.bare.AddNewAuthorityIdentifierHandlerTest.BARE_SINGLE_AUTHORITY_GET_RESPONSE_JSON;
-import static no.unit.nva.bare.AuthorityConverterTest.HTTPS_LOCALHOST_PERSON_WITHOUT_TRAILING_SLASH;
 import static no.unit.nva.bare.FetchAuthorityHandler.ARPID_KEY;
 import static no.unit.nva.bare.FetchAuthorityHandler.QUERY_STRING_PARAMETERS_KEY;
 import static nva.commons.core.JsonUtils.objectMapperWithEmpty;
@@ -58,8 +57,6 @@ public class FetchAuthorityHandlerTest {
         httpClient = mock(HttpClient.class);
         bareConnection = new BareConnection(httpClient);
         mockEnvironment = mock(Environment.class);
-        when(mockEnvironment.readEnv(AuthorityConverter.PERSON_AUTHORITY_BASE_ADDRESS_KEY))
-            .thenReturn(HTTPS_LOCALHOST_PERSON_WITHOUT_TRAILING_SLASH);
     }
 
     @Test
@@ -69,7 +66,7 @@ public class FetchAuthorityHandlerTest {
 
         Map<String, Object> event = createEvent(NAME_KEY, "destroyer");
 
-        FetchAuthorityHandler mockAuthorityProxy = new FetchAuthorityHandler(bareConnection, mockEnvironment);
+        FetchAuthorityHandler mockAuthorityProxy = new FetchAuthorityHandler(bareConnection);
         CustomGatewayResponse result = mockAuthorityProxy.handleRequest(event, null);
         assertEquals(HTTP_OK, result.getStatusCode());
         assertEquals(result.getHeaders().get(HttpHeaders.CONTENT_TYPE), ContentTypes.APPLICATION_JSON);
@@ -92,7 +89,7 @@ public class FetchAuthorityHandlerTest {
 
         Map<String, Object> event = createEvent(ARPID_KEY, SAMPLE_IDENTIFIER);
 
-        FetchAuthorityHandler handler = new FetchAuthorityHandler(bareConnection, mockEnvironment);
+        FetchAuthorityHandler handler = new FetchAuthorityHandler(bareConnection);
         CustomGatewayResponse result = handler.handleRequest(event, null);
         assertEquals(HTTP_OK, result.getStatusCode());
         assertEquals(result.getHeaders().get(HttpHeaders.CONTENT_TYPE), TestHeaders.APPLICATION_JSON);
@@ -105,7 +102,7 @@ public class FetchAuthorityHandlerTest {
         whenSendingRequest().thenThrow(new IOException(MY_MOCK_THROWS_AN_EXCEPTION));
 
         Map<String, Object> event = createEvent(ARPID_KEY, SAMPLE_IDENTIFIER);
-        FetchAuthorityHandler mockAuthorityProxy = new FetchAuthorityHandler(bareConnection, mockEnvironment);
+        FetchAuthorityHandler mockAuthorityProxy = new FetchAuthorityHandler(bareConnection);
         CustomGatewayResponse result = mockAuthorityProxy.handleRequest(event, null);
         assertEquals(HTTP_INTERNAL_ERROR, result.getStatusCode());
         String content = result.getBody();
@@ -119,7 +116,7 @@ public class FetchAuthorityHandlerTest {
         whenSendingRequest().thenAnswer(invocation -> mockHttpResponse(responseBody, HTTP_OK));
 
         Map<String, Object> event = createEvent(FEIDEID_KEY, "sarah.serussi@unit.no");
-        FetchAuthorityHandler mockAuthorityProxy = new FetchAuthorityHandler(bareConnection, mockEnvironment);
+        FetchAuthorityHandler mockAuthorityProxy = new FetchAuthorityHandler(bareConnection);
         CustomGatewayResponse result = mockAuthorityProxy.handleRequest(event, null);
         assertEquals(HTTP_OK, result.getStatusCode());
         assertEquals(result.getHeaders().get(HttpHeaders.CONTENT_TYPE), TestHeaders.APPLICATION_JSON);
@@ -138,7 +135,7 @@ public class FetchAuthorityHandlerTest {
     public void testHandlerWithNull_QueryParams() throws Exception {
         Map<String, Object> event = new HashMap<>();
         event.put(QUERY_STRING_PARAMETERS_KEY, null);
-        FetchAuthorityHandler mockAuthorityProxy = new FetchAuthorityHandler(bareConnection, mockEnvironment);
+        FetchAuthorityHandler mockAuthorityProxy = new FetchAuthorityHandler(bareConnection);
         CustomGatewayResponse result = mockAuthorityProxy.handleRequest(event, null);
         assertEquals(HTTP_BAD_REQUEST, result.getStatusCode());
         String content = result.getBody();
@@ -153,7 +150,7 @@ public class FetchAuthorityHandlerTest {
         whenSendingRequest().thenAnswer(invocation -> mockHttpResponse(responseBody, HTTP_OK));
         Map<String, Object> event = createEvent(ORCID_KEY, SAMPLE_IDENTIFIER);
 
-        FetchAuthorityHandler mockAuthorityProxy = new FetchAuthorityHandler(bareConnection, mockEnvironment);
+        FetchAuthorityHandler mockAuthorityProxy = new FetchAuthorityHandler(bareConnection);
         CustomGatewayResponse result = mockAuthorityProxy.handleRequest(event, null);
         assertEquals(HTTP_OK, result.getStatusCode());
         assertEquals(result.getHeaders().get(HttpHeaders.CONTENT_TYPE), TestHeaders.APPLICATION_JSON);
@@ -174,7 +171,7 @@ public class FetchAuthorityHandlerTest {
 
     @Test
     public void testResponseWithoutQueryParams() {
-        FetchAuthorityHandler mockAuthorityProxy = new FetchAuthorityHandler(bareConnection, mockEnvironment);
+        FetchAuthorityHandler mockAuthorityProxy = new FetchAuthorityHandler(bareConnection);
 
         CustomGatewayResponse result = mockAuthorityProxy.handleRequest(null, null);
         assertEquals(HTTP_BAD_REQUEST, result.getStatusCode());
@@ -196,7 +193,7 @@ public class FetchAuthorityHandlerTest {
 
         Map<String, Object> event = createEvent(FEIDEID_KEY, "sarha.suressi@unit.no");
 
-        FetchAuthorityHandler mockAuthorityProxy = new FetchAuthorityHandler(bareConnection, mockEnvironment);
+        FetchAuthorityHandler mockAuthorityProxy = new FetchAuthorityHandler(bareConnection);
         CustomGatewayResponse result = mockAuthorityProxy.handleRequest(event, null);
         assertEquals(HTTP_OK, result.getStatusCode());
         assertEquals(result.getHeaders().get(nva.commons.apigateway.HttpHeaders.CONTENT_TYPE),
@@ -214,7 +211,7 @@ public class FetchAuthorityHandlerTest {
         whenSendingRequest().thenThrow(new IOException(MY_MOCK_THROWS_AN_EXCEPTION));
 
         Map<String, Object> event = createEvent(FEIDEID_KEY, "sarha.suressi@unit.no");
-        FetchAuthorityHandler mockAuthorityProxy = new FetchAuthorityHandler(bareConnection, mockEnvironment);
+        FetchAuthorityHandler mockAuthorityProxy = new FetchAuthorityHandler(bareConnection);
         CustomGatewayResponse result = mockAuthorityProxy.handleRequest(event, null);
         assertEquals(HTTP_INTERNAL_ERROR, result.getStatusCode());
         String content = result.getBody();
@@ -225,7 +222,7 @@ public class FetchAuthorityHandlerTest {
     @Test
     public void testNoBodyRequest() {
         Map<String, Object> event = new HashMap<>();
-        FetchAuthorityHandler fetchAuthorityHandler = new FetchAuthorityHandler(bareConnection, mockEnvironment);
+        FetchAuthorityHandler fetchAuthorityHandler = new FetchAuthorityHandler(bareConnection);
         CustomGatewayResponse result = fetchAuthorityHandler.handleRequest(event, null);
         assertEquals(HTTP_BAD_REQUEST, result.getStatusCode());
         String content = result.getBody();

--- a/src/test/java/no/unit/nva/bare/UpdateAuthorityIdentifierHandlerTest.java
+++ b/src/test/java/no/unit/nva/bare/UpdateAuthorityIdentifierHandlerTest.java
@@ -3,7 +3,6 @@ package no.unit.nva.bare;
 import static java.net.HttpURLConnection.HTTP_BAD_REQUEST;
 import static java.net.HttpURLConnection.HTTP_FORBIDDEN;
 import static java.net.HttpURLConnection.HTTP_OK;
-import static no.unit.nva.bare.AuthorityConverterTest.HTTPS_LOCALHOST_PERSON;
 import static no.unit.nva.bare.UpdateAuthorityIdentifierHandler.COMMUNICATION_ERROR_WHILE_RETRIEVING_UPDATED_AUTHORITY;
 import static no.unit.nva.bare.UpdateAuthorityIdentifierHandler.INVALID_VALUE_PATH_PARAMETER_QUALIFIER;
 import static no.unit.nva.bare.UpdateAuthorityIdentifierHandler.MISSING_ATTRIBUTE_IDENTIFIER;
@@ -14,7 +13,6 @@ import static no.unit.nva.bare.UpdateAuthorityIdentifierHandler.MISSING_REQUEST_
 import static no.unit.nva.bare.UpdateAuthorityIdentifierHandler.QUALIFIER_KEY;
 import static no.unit.nva.bare.UpdateAuthorityIdentifierHandler.REMOTE_SERVER_ERRORMESSAGE;
 import static no.unit.nva.bare.UpdateAuthorityIdentifierHandler.SCN_KEY;
-import static nva.commons.apigateway.ApiGatewayHandler.ALLOWED_ORIGIN_ENV;
 import static nva.commons.core.JsonUtils.objectMapperWithEmpty;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
@@ -39,7 +37,6 @@ import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import no.unit.nva.testutils.HandlerUtils;
 import no.unit.nva.testutils.TestHeaders;
-import nva.commons.core.Environment;
 import nva.commons.core.StringUtils;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -57,7 +54,6 @@ public class UpdateAuthorityIdentifierHandlerTest {
     public static final URI MOCK_IDENTIFIER_URI = URI.create("https://example.org/originalidentifier");
     public static final URI MOCK_UPDATED_IDENTIFIER_URI = URI.create("https://example.org/originalidentifier");
 
-    private Environment mockEnvironment;
     private Context context;
     private BareConnection bareConnection;
     private OutputStream output;
@@ -69,10 +65,6 @@ public class UpdateAuthorityIdentifierHandlerTest {
      */
     @BeforeEach
     public void setUp() {
-        mockEnvironment = mock(Environment.class);
-        when(mockEnvironment.readEnv(ALLOWED_ORIGIN_ENV)).thenReturn("*");
-        when(mockEnvironment.readEnv(AuthorityConverter.PERSON_AUTHORITY_BASE_ADDRESS_KEY))
-            .thenReturn(HTTPS_LOCALHOST_PERSON);
         context = mock(Context.class);
         output = new ByteArrayOutputStream();
         bareConnection = mock(BareConnection.class);
@@ -84,7 +76,7 @@ public class UpdateAuthorityIdentifierHandlerTest {
     public void handlerReturnsBadRequestWhenScnPathParameterIsMissing() throws IOException {
 
         InputStream input = new HandlerUtils(objectMapperWithEmpty).requestObjectToApiGatewayRequestInputSteam(null);
-        updateAuthorityIdentifierHandler = new UpdateAuthorityIdentifierHandler(mockEnvironment, bareConnection);
+        updateAuthorityIdentifierHandler = new UpdateAuthorityIdentifierHandler(bareConnection);
         updateAuthorityIdentifierHandler.handleRequest(input, output, context);
 
         nva.commons.apigateway.GatewayResponse gatewayResponse =
@@ -106,7 +98,7 @@ public class UpdateAuthorityIdentifierHandlerTest {
                                                                                                                TestHeaders.getRequestHeaders(),
                                                                                                                pathParams,
                                                                                                                null);
-        updateAuthorityIdentifierHandler = new UpdateAuthorityIdentifierHandler(mockEnvironment, bareConnection);
+        updateAuthorityIdentifierHandler = new UpdateAuthorityIdentifierHandler(bareConnection);
         updateAuthorityIdentifierHandler.handleRequest(input, output, context);
 
         nva.commons.apigateway.GatewayResponse gatewayResponse = objectMapperWithEmpty.readValue(output.toString(),
@@ -129,7 +121,7 @@ public class UpdateAuthorityIdentifierHandlerTest {
                                                                                                                TestHeaders.getRequestHeaders(),
                                                                                                                pathParams,
                                                                                                                null);
-        updateAuthorityIdentifierHandler = new UpdateAuthorityIdentifierHandler(mockEnvironment, bareConnection);
+        updateAuthorityIdentifierHandler = new UpdateAuthorityIdentifierHandler(bareConnection);
         updateAuthorityIdentifierHandler.handleRequest(input, output, context);
 
         nva.commons.apigateway.GatewayResponse gatewayResponse =
@@ -151,7 +143,7 @@ public class UpdateAuthorityIdentifierHandlerTest {
                                                                                                                TestHeaders.getRequestHeaders(),
                                                                                                                pathParams,
                                                                                                                null);
-        updateAuthorityIdentifierHandler = new UpdateAuthorityIdentifierHandler(mockEnvironment, bareConnection);
+        updateAuthorityIdentifierHandler = new UpdateAuthorityIdentifierHandler(bareConnection);
         updateAuthorityIdentifierHandler.handleRequest(input, output, context);
 
         nva.commons.apigateway.GatewayResponse gatewayResponse =
@@ -175,7 +167,7 @@ public class UpdateAuthorityIdentifierHandlerTest {
             objectMapperWithEmpty).requestObjectToApiGatewayRequestInputSteam(requestObject,
                                                                               TestHeaders.getRequestHeaders(),
                                                                               pathParams, null);
-        updateAuthorityIdentifierHandler = new UpdateAuthorityIdentifierHandler(mockEnvironment, bareConnection);
+        updateAuthorityIdentifierHandler = new UpdateAuthorityIdentifierHandler(bareConnection);
         updateAuthorityIdentifierHandler.handleRequest(input, output, context);
 
         nva.commons.apigateway.GatewayResponse gatewayResponse =
@@ -199,7 +191,7 @@ public class UpdateAuthorityIdentifierHandlerTest {
             objectMapperWithEmpty).requestObjectToApiGatewayRequestInputSteam(requestObject,
                                                                               TestHeaders.getRequestHeaders(),
                                                                               pathParams, null);
-        updateAuthorityIdentifierHandler = new UpdateAuthorityIdentifierHandler(mockEnvironment, bareConnection);
+        updateAuthorityIdentifierHandler = new UpdateAuthorityIdentifierHandler(bareConnection);
         updateAuthorityIdentifierHandler.handleRequest(input, output, context);
 
         nva.commons.apigateway.GatewayResponse gatewayResponse =
@@ -224,7 +216,7 @@ public class UpdateAuthorityIdentifierHandlerTest {
         when(httpResponse.statusCode()).thenReturn(HTTP_OK);
         when(bareConnection.updateIdentifier(any(), any(), any(), any())).thenReturn(httpResponse);
 
-        updateAuthorityIdentifierHandler = new UpdateAuthorityIdentifierHandler(mockEnvironment, bareConnection);
+        updateAuthorityIdentifierHandler = new UpdateAuthorityIdentifierHandler(bareConnection);
         UpdateAuthorityIdentifierRequest requestObject = new UpdateAuthorityIdentifierRequest(MOCK_FEIDEID_VALUE,
                                                                                               MOCK_FEIDEID_VALUE);
         Map<String, String> pathParams = getPathParameters(MOCK_SCN_VALUE, ValidIdentifierKey.FEIDEID.asString());
@@ -270,7 +262,7 @@ public class UpdateAuthorityIdentifierHandlerTest {
             new IOException(EXCEPTION_IS_EXPECTED));
 
         UpdateAuthorityIdentifierHandler updateAuthorityIdentifierHandler =
-            new UpdateAuthorityIdentifierHandler(mockEnvironment, bareConnection);
+            new UpdateAuthorityIdentifierHandler(bareConnection);
         UpdateAuthorityIdentifierRequest requestObject = new UpdateAuthorityIdentifierRequest(MOCK_FEIDEID_VALUE,
                                                                                               MOCK_FEIDEID_VALUE);
         Map<String, String> pathParams = getPathParameters(MOCK_SCN_VALUE, ValidIdentifierKey.FEIDEID.asString());
@@ -297,7 +289,7 @@ public class UpdateAuthorityIdentifierHandlerTest {
         when(bareConnection.get(any())).thenReturn(null);
         when(bareConnection.updateIdentifier(any(), any(), any(), any())).thenReturn(httpResponse);
 
-        updateAuthorityIdentifierHandler = new UpdateAuthorityIdentifierHandler(mockEnvironment, bareConnection);
+        updateAuthorityIdentifierHandler = new UpdateAuthorityIdentifierHandler(bareConnection);
         UpdateAuthorityIdentifierRequest requestObject = new UpdateAuthorityIdentifierRequest(MOCK_FEIDEID_VALUE,
                                                                                               MOCK_FEIDEID_VALUE);
         Map<String, String> pathParams = getPathParameters(MOCK_SCN_VALUE, ValidIdentifierKey.FEIDEID.asString());
@@ -324,7 +316,7 @@ public class UpdateAuthorityIdentifierHandlerTest {
         when(bareConnection.get(any())).thenThrow(new IOException(EXCEPTION_IS_EXPECTED));
         when(bareConnection.updateIdentifier(any(), any(), any(), any())).thenReturn(httpResponse);
 
-        updateAuthorityIdentifierHandler = new UpdateAuthorityIdentifierHandler(mockEnvironment, bareConnection);
+        updateAuthorityIdentifierHandler = new UpdateAuthorityIdentifierHandler(bareConnection);
         UpdateAuthorityIdentifierRequest requestObject = new UpdateAuthorityIdentifierRequest(MOCK_FEIDEID_VALUE,
                                                                                               MOCK_FEIDEID_VALUE);
         Map<String, String> pathParams = getPathParameters(MOCK_SCN_VALUE, ValidIdentifierKey.FEIDEID.asString());
@@ -350,7 +342,7 @@ public class UpdateAuthorityIdentifierHandlerTest {
         when(httpResponse.statusCode()).thenReturn(HTTP_FORBIDDEN);
         when(bareConnection.updateIdentifier(any(), any(), any(), any())).thenReturn(httpResponse);
 
-        updateAuthorityIdentifierHandler = new UpdateAuthorityIdentifierHandler(mockEnvironment, bareConnection);
+        updateAuthorityIdentifierHandler = new UpdateAuthorityIdentifierHandler(bareConnection);
         UpdateAuthorityIdentifierRequest requestObject = new UpdateAuthorityIdentifierRequest(MOCK_FEIDEID_VALUE,
                                                                                               MOCK_FEIDEID_VALUE);
         Map<String, String> pathParams = getPathParameters(MOCK_SCN_VALUE, ValidIdentifierKey.FEIDEID.asString());
@@ -372,7 +364,7 @@ public class UpdateAuthorityIdentifierHandlerTest {
     private void initMockUpdateAuthorityIdentifierHandler() throws
                                                             InterruptedException, BareCommunicationException,
                                                             BareException {
-        updateAuthorityIdentifierHandler = spy(new UpdateAuthorityIdentifierHandler(mockEnvironment, bareConnection));
+        updateAuthorityIdentifierHandler = spy(new UpdateAuthorityIdentifierHandler(bareConnection));
         Authority mockAuthority = mock(Authority.class);
         doReturn(mockAuthority).when(updateAuthorityIdentifierHandler).getAuthority(any());
     }


### PR DESCRIPTION
BARE has two delete endpoints (https://alfa-a.bibsys.no/authority/) I was using the "path-parameters-only" but it fails for values that are URIs. I changed it to the one that is using both path and query parameters. 
During testing I struggled with setting up the environment. Since all mocked environments had hardcoded values I put these values in the test configuration and removed the mocked environments.